### PR TITLE
Implement voice search and fix Home search bar behavior

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     <!-- Internet permission for API calls and URL launching -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- Microphone for speech recognition -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     
     <application
         android:label="songbuddy"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,6 +45,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<!-- Microphone permission for voice search -->
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This is used to capture your voice for search.</string>
 	<!-- Deep link URL scheme for Spotify OAuth callback -->
 	<key>CFBundleURLTypes</key>
 	<array>

--- a/lib/screens/home_feed_screen.dart
+++ b/lib/screens/home_feed_screen.dart
@@ -2,49 +2,94 @@ import 'dart:async';
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:songbuddy/constants/app_colors.dart';
+import 'package:speech_to_text/speech_recognition_result.dart';
+import 'package:speech_to_text/speech_to_text.dart';
 
-class HomeFeedScreen extends StatelessWidget {
+class HomeFeedScreen extends StatefulWidget {
   const HomeFeedScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    // richer dummy data with likes & timestamp
-    final dummyPosts = [
-      {
-        "username": "Amin",
-        "avatarUrl": "https://i.pravatar.cc/150?img=1",
-        "trackTitle": "Blinding Lights",
-        "artist": "The Weeknd",
-        "coverUrl":
-            "https://i.scdn.co/image/ab67616d00001e02257c60eb99821fe397f817b2",
-        "description": "This track always gives me a boost of energy 🚀🔥",
-        "likes": 124,
-        "time": "2h"
-      },
-      {
-        "username": "Sara",
-        "avatarUrl": "https://i.pravatar.cc/150?img=2",
-        "trackTitle": "Levitating",
-        "artist": "Dua Lipa",
-        "coverUrl":
-            "https://i.scdn.co/image/ab67616d00001e02257c60eb99821fe397f817b2",
-        "description": "",
-        "likes": 89,
-        "time": "6h"
-      },
-      {
-        "username": "John",
-        "avatarUrl": "https://i.pravatar.cc/150?img=3",
-        "trackTitle": "As It Was",
-        "artist": "Harry Styles",
-        "coverUrl":
-            "https://i.scdn.co/image/ab67616d00001e02257c60eb99821fe397f817b2",
-        "description": "Makes me feel nostalgic ✨",
-        "likes": 211,
-        "time": "1d"
-      },
-    ];
+  State<HomeFeedScreen> createState() => _HomeFeedScreenState();
+}
 
+class _HomeFeedScreenState extends State<HomeFeedScreen> {
+  // richer dummy data with likes & timestamp
+  final List<Map<String, dynamic>> _allPosts = [
+    {
+      "username": "Amin",
+      "avatarUrl": "https://i.pravatar.cc/150?img=1",
+      "trackTitle": "Blinding Lights",
+      "artist": "The Weeknd",
+      "coverUrl":
+          "https://i.scdn.co/image/ab67616d00001e02257c60eb99821fe397f817b2",
+      "description": "This track always gives me a boost of energy 🚀🔥",
+      "likes": 124,
+      "time": "2h"
+    },
+    {
+      "username": "Sara",
+      "avatarUrl": "https://i.pravatar.cc/150?img=2",
+      "trackTitle": "Levitating",
+      "artist": "Dua Lipa",
+      "coverUrl":
+          "https://i.scdn.co/image/ab67616d00001e02257c60eb99821fe397f817b2",
+      "description": "",
+      "likes": 89,
+      "time": "6h"
+    },
+    {
+      "username": "John",
+      "avatarUrl": "https://i.pravatar.cc/150?img=3",
+      "trackTitle": "As It Was",
+      "artist": "Harry Styles",
+      "coverUrl":
+          "https://i.scdn.co/image/ab67616d00001e02257c60eb99821fe397f817b2",
+      "description": "Makes me feel nostalgic ✨",
+      "likes": 211,
+      "time": "1d"
+    },
+  ];
+
+  late List<Map<String, dynamic>> _filteredPosts;
+  String _query = '';
+  Timer? _debounce;
+
+  @override
+  void initState() {
+    super.initState();
+    _filteredPosts = List<Map<String, dynamic>>.from(_allPosts);
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  void _onQueryChanged(String query) {
+    _query = query.trim();
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 360), _applyFilter);
+  }
+
+  void _applyFilter() {
+    if (_query.isEmpty) {
+      setState(() => _filteredPosts = List<Map<String, dynamic>>.from(_allPosts));
+      return;
+    }
+    final lower = _query.toLowerCase();
+    setState(() {
+      _filteredPosts = _allPosts.where((post) {
+        final username = (post['username'] as String).toLowerCase();
+        final title = (post['trackTitle'] as String).toLowerCase();
+        final artist = (post['artist'] as String).toLowerCase();
+        return username.contains(lower) || title.contains(lower) || artist.contains(lower);
+      }).toList();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       // Gradient background for depth & modern look
       body: Container(
@@ -71,7 +116,9 @@ class HomeFeedScreen extends StatelessWidget {
                     CircleAvatar(
                       radius: 18,
                       backgroundImage:
-                          NetworkImage(dummyPosts[0]["avatarUrl"] as String),
+                          NetworkImage(((_filteredPosts.isNotEmpty
+                                      ? _filteredPosts
+                                      : _allPosts)[0]["avatarUrl"]) as String),
                       backgroundColor: Colors.transparent,
                     ),
                     const Spacer(),
@@ -131,10 +178,18 @@ class HomeFeedScreen extends StatelessWidget {
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                 child: Column(
                   children: const [
-                    _ModernSearchBar(),
-                    SizedBox(height: 12),
+                    SizedBox(height: 0),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
+                child: Column(
+                  children: [
+                    _ModernSearchBar(onQueryChanged: _onQueryChanged),
+                    const SizedBox(height: 12),
                     // Suggestion chips below
-                    SizedBox(
+                    const SizedBox(
                       height: 36,
                       child: _SuggestionChipsRow(),
                     ),
@@ -146,9 +201,9 @@ class HomeFeedScreen extends StatelessWidget {
               Expanded(
                 child: ListView.builder(
                   padding: const EdgeInsets.only(top: 6, bottom: 18),
-                  itemCount: dummyPosts.length,
+                  itemCount: _filteredPosts.length,
                   itemBuilder: (context, index) {
-                    final post = dummyPosts[index];
+                    final post = _filteredPosts[index];
                     return _MusicPostCard(
                       index: index,
                       username: post["username"] as String,
@@ -217,7 +272,8 @@ class _SuggestionChipsRow extends StatelessWidget {
 }
 
 class _ModernSearchBar extends StatefulWidget {
-  const _ModernSearchBar();
+  final void Function(String query)? onQueryChanged;
+  const _ModernSearchBar({this.onQueryChanged});
 
   @override
   State<_ModernSearchBar> createState() => _ModernSearchBarState();
@@ -228,6 +284,13 @@ class _ModernSearchBarState extends State<_ModernSearchBar>
   late final FocusNode _focusNode;
   late final AnimationController _controller;
   late final Animation<double> _glowAnim;
+  final TextEditingController _textController = TextEditingController();
+
+  // Speech
+  final SpeechToText _speech = SpeechToText();
+  bool _hasSpeech = false;
+  bool _isListening = false;
+  String _lastError = '';
 
   @override
   void initState() {
@@ -251,9 +314,96 @@ class _ModernSearchBarState extends State<_ModernSearchBar>
 
   @override
   void dispose() {
+    _speech.stop();
+    _textController.dispose();
     _focusNode.dispose();
     _controller.dispose();
     super.dispose();
+  }
+
+  Future<void> _initSpeech() async {
+    final hasSpeech = await _speech.initialize(
+      onStatus: (status) {
+        if (!mounted) return;
+        if (status == 'notListening') {
+          setState(() => _isListening = false);
+        }
+      },
+      onError: (e) {
+        if (!mounted) return;
+        setState(() => _lastError = e.errorMsg);
+      },
+    );
+    if (!mounted) return;
+    setState(() => _hasSpeech = hasSpeech);
+  }
+
+  Future<void> _startListening() async {
+    if (!_hasSpeech) {
+      await _initSpeech();
+    }
+    setState(() {
+      _isListening = true;
+      _lastError = '';
+    });
+    await _speech.listen(
+      onResult: _onSpeechResult,
+      listenMode: ListenMode.search,
+      partialResults: true,
+      cancelOnError: true,
+      // Wait longer for the user to speak / pause between words
+      pauseFor: const Duration(seconds: 5),
+      listenFor: const Duration(seconds: 20),
+      localeId: null,
+    );
+  }
+
+  Future<void> _stopListening() async {
+    await _speech.stop();
+    if (!mounted) return;
+    setState(() => _isListening = false);
+  }
+
+  void _onSpeechResult(SpeechRecognitionResult result) {
+    if (!mounted) return;
+    final recognized = result.recognizedWords.trim();
+    _textController.value = _textController.value.copyWith(
+      text: recognized,
+      selection: TextSelection.collapsed(offset: recognized.length),
+    );
+    widget.onQueryChanged?.call(recognized);
+  }
+
+  Future<void> _onMicPressed() async {
+    if (_isListening) {
+      await _stopListening();
+      return;
+    }
+    if (!_hasSpeech) {
+      await _initSpeech();
+    }
+    if (!_hasSpeech) {
+      if (!mounted) return;
+      // Show a simple permission dialog
+      await showDialog<void>(
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: const Text('Microphone permission'),
+            content: const Text(
+                'Voice search needs access to your microphone. Please allow microphone permission in system settings.'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          );
+        },
+      );
+      return;
+    }
+    await _startListening();
   }
 
   @override
@@ -312,6 +462,7 @@ class _ModernSearchBarState extends State<_ModernSearchBar>
                       Expanded(
                         child: TextField(
                           focusNode: _focusNode,
+                          controller: _textController,
                           style: const TextStyle(color: Colors.white),
                           cursorColor: const Color(0xFF5EEAD4),
                           decoration: InputDecoration(
@@ -327,12 +478,19 @@ class _ModernSearchBarState extends State<_ModernSearchBar>
                             fillColor: Colors.transparent,
                             contentPadding: const EdgeInsets.symmetric(vertical: 14),
                           ),
+                          textInputAction: TextInputAction.search,
+                          onChanged: widget.onQueryChanged,
+                          onSubmitted: widget.onQueryChanged,
                         ),
                       ),
                       IconButton(
-                        onPressed: () {},
-                        icon: const Icon(Icons.mic_rounded,
-                            color: Colors.white70, size: 22),
+                        onPressed: _onMicPressed,
+                        icon: Icon(
+                          _isListening ? Icons.stop_circle_rounded : Icons.mic_rounded,
+                          color: _isListening ? const Color(0xFF5EEAD4) : Colors.white70,
+                          size: 22,
+                        ),
+                        tooltip: _isListening ? 'Stop listening' : 'Voice search',
                       ),
                     ],
                   ),

--- a/lib/screens/home_feed_screen.dart
+++ b/lib/screens/home_feed_screen.dart
@@ -463,6 +463,7 @@ class _ModernSearchBarState extends State<_ModernSearchBar>
                         child: TextField(
                           focusNode: _focusNode,
                           controller: _textController,
+                          magnifierConfiguration: TextMagnifierConfiguration.disabled,
                           style: const TextStyle(color: Colors.white),
                           cursorColor: const Color(0xFF5EEAD4),
                           decoration: InputDecoration(

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,11 +8,13 @@ import Foundation
 import connectivity_plus
 import flutter_secure_storage_macos
 import path_provider_foundation
+import speech_to_text_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SpeechToTextMacosPlugin.register(with: registry.registrar(forPlugin: "SpeechToTextMacosPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -200,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -320,6 +328,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:
@@ -357,6 +373,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  speech_to_text:
+    dependency: "direct main"
+    description:
+      name: speech_to_text
+      sha256: "57fef1d41bdebe298e84842c89bb4ac91f31cdbec7830c8cb1fc6b91d03abd42"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
+  speech_to_text_macos:
+    dependency: transitive
+    description:
+      name: speech_to_text_macos
+      sha256: e685750f7542fcaa087a5396ee471e727ec648bf681f4da83c84d086322173f6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  speech_to_text_platform_interface:
+    dependency: transitive
+    description:
+      name: speech_to_text_platform_interface
+      sha256: a1935847704e41ee468aad83181ddd2423d0833abe55d769c59afca07adb5114
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,8 @@ dependencies:
   flutter_secure_storage: ^9.0.0
   # Connectivity checking
   connectivity_plus: ^6.0.5
+  # Speech recognition
+  speech_to_text: ^6.5.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
**Summary:**
Adds voice-to-text search on the Home screen and improves search bar reliability (debounce, submission, clear UX tweaks). 
Mic asks for permission on tap and waits longer while the user speaks.

**What’s changed:**
Voice search
  Integrated speech_to_text with start/stop via mic button
  Requests microphone permission when mic is tapped
  Extended listening window and silence timeout for natural pauses
  Populates the search field in real time and triggers the same search flow as typed input
Search bar reliability
  Debounced query handling to avoid overlapping/stale results
  Keyboard Search/Done submits current query
  Disabled system text magnifier on the search field to avoid zoom loupe
Home feed filtering (local data for now)
  Filters by username, track title, and artist

**Platform/Permissions:**
  Android: added RECORD_AUDIO to android/app/src/main/AndroidManifest.xml
  iOS: added NSMicrophoneUsageDescription to ios/Runner/Info.plist
  Dependency: speech_to_text

**Screens/Files Touched:**
  lib/screens/home_feed_screen.dart
  pubspec.yaml (+ pubspec.lock)
  android/app/src/main/AndroidManifest.xml
  ios/Runner/Info.plist

**Test plan:**
  Tap mic → permission prompt shown on first use; allow and speak a query
  Speak with short and long pauses; ensure text updates and results filter
  Type fast/backspace; no flicker or stale results
  Submit via keyboard action; results update accordingly
  Deny permission → non-blocking dialog shown
  Navigate away and back; search still functions

**Edge cases:**
  Empty query resets results to default feed
  Partial results update as speech is recognized
  Stop listening button ends capture immediately

**Co-authors:**
  Co-authored-by: Mohsen Kashefi <MohsenKashefi2016@yahoo.com>
